### PR TITLE
Add implementation to store PushDeviceRegistrationRequestCache into temp session DB

### DIFF
--- a/components/org.wso2.carbon.identity.notification.push.device.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
@@ -133,6 +137,7 @@
                             org.wso2.carbon.identity.notification.sender.tenant.config; version="${identity.event.handler.notification.imp.pkg.version.range}",
                             org.wso2.carbon.identity.notification.sender.tenant.config.dto; version="${identity.event.handler.notification.imp.pkg.version.range}",
                             org.wso2.carbon.identity.notification.sender.tenant.config.exception; version="${identity.event.handler.notification.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.store; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.database.utils.jdbc;version="${org.wso2.carbon.database.utils.version.range}",

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/cache/DeviceRegistrationRequestCache.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/cache/DeviceRegistrationRequestCache.java
@@ -21,13 +21,14 @@ package org.wso2.carbon.identity.notification.push.device.handler.cache;
 import org.wso2.carbon.identity.core.cache.BaseCache;
 import org.wso2.carbon.utils.CarbonUtils;
 
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_REGISTRATION_REQUEST_CACHE;
+
 /**
  * Device registration request cache.
  */
 public class DeviceRegistrationRequestCache extends BaseCache<DeviceRegistrationRequestCacheKey,
         DeviceRegistrationRequestCacheEntry> {
 
-    private static final String DEVICE_REGISTRATION_REQUEST_CACHE = "DeviceRegistrationRequestCache";
     private static volatile DeviceRegistrationRequestCache instance;
 
     /**
@@ -35,7 +36,7 @@ public class DeviceRegistrationRequestCache extends BaseCache<DeviceRegistration
      */
     private DeviceRegistrationRequestCache() {
 
-        super(DEVICE_REGISTRATION_REQUEST_CACHE);
+        super(DEVICE_REGISTRATION_REQUEST_CACHE, true);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
@@ -25,6 +25,7 @@ public class PushDeviceHandlerConstants {
 
     public static final String HASHING_ALGORITHM = "SHA256withRSA";
     public static final String SIGNATURE_ALGORITHM = "RSA";
+    public static final String DEVICE_REGISTRATION_REQUEST_CACHE = "PushDeviceRegistrationRequestCache";
 
     /**
      * Private constructor to prevent initialization of the class.

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
@@ -91,7 +91,7 @@ public class PushDeviceHandlerConstants {
         ),
         ERROR_CODE_DEVICE_ALREADY_REGISTERED(
                 "PDH-15003",
-                "Device already registered for the device ID: %s."
+                "The corresponding user has already registered a device for push notification."
         ),
         ERROR_CODE_SIGNATURE_VERIFICATION_FAILED(
                 "PDH-15004",

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
@@ -351,10 +351,9 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
         try {
             Device existingDevice = getDeviceByUserId(userId, tenantDomain);
             if (existingDevice != null) {
-                String errorMessage = String.format(ERROR_CODE_DEVICE_ALREADY_REGISTERED.toString(),
-                        registrationRequest.getDeviceId());
                 throw new PushDeviceHandlerClientException(
-                        ERROR_CODE_DEVICE_ALREADY_REGISTERED.getCode(), errorMessage);
+                        ERROR_CODE_DEVICE_ALREADY_REGISTERED.getCode(),
+                        ERROR_CODE_DEVICE_ALREADY_REGISTERED.toString());
             }
         } catch (PushDeviceHandlerClientException e) {
             // This means there is no existing device registered for the user.

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceRegistrationContextManagerImpl.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceRegistrationContextManagerImpl.java
@@ -18,11 +18,14 @@
 
 package org.wso2.carbon.identity.notification.push.device.handler.impl;
 
+import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
 import org.wso2.carbon.identity.notification.push.device.handler.DeviceRegistrationContextManager;
 import org.wso2.carbon.identity.notification.push.device.handler.cache.DeviceRegistrationRequestCache;
 import org.wso2.carbon.identity.notification.push.device.handler.cache.DeviceRegistrationRequestCacheEntry;
 import org.wso2.carbon.identity.notification.push.device.handler.cache.DeviceRegistrationRequestCacheKey;
 import org.wso2.carbon.identity.notification.push.device.handler.model.DeviceRegistrationContext;
+
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_REGISTRATION_REQUEST_CACHE;
 
 /**
  * Device registration cache manager implementation.
@@ -36,6 +39,7 @@ public class DeviceRegistrationContextManagerImpl implements DeviceRegistrationC
                 new DeviceRegistrationRequestCacheKey(key),
                 new DeviceRegistrationRequestCacheEntry(context),
                 tenantDomain);
+        storeToSessionStore(key, new DeviceRegistrationRequestCacheEntry(context));
     }
 
     @Override
@@ -45,8 +49,9 @@ public class DeviceRegistrationContextManagerImpl implements DeviceRegistrationC
                 new DeviceRegistrationRequestCacheKey(key), tenantDomain);
         if (cacheEntry != null) {
             return cacheEntry.getDeviceRegistrationContext();
+        } else {
+            return getFromSessionStore(key).getDeviceRegistrationContext();
         }
-        return null;
     }
 
     @Override
@@ -54,5 +59,39 @@ public class DeviceRegistrationContextManagerImpl implements DeviceRegistrationC
 
         DeviceRegistrationRequestCache.getInstance().clearCacheEntry(
                 new DeviceRegistrationRequestCacheKey(key), tenantDomain);
+        clearFromSessionStore(key);
+    }
+
+    /**
+     * Store device registration context in session store.
+     *
+     * @param id            Unique key for identifying the device registration context for the session.
+     * @param entry         Device registration context cache entry.
+     */
+    private void storeToSessionStore(String id, DeviceRegistrationRequestCacheEntry entry) {
+
+        SessionDataStore.getInstance().storeSessionData(id, DEVICE_REGISTRATION_REQUEST_CACHE, entry);
+    }
+
+    /**
+     * Get device registration context from session store.
+     *
+     * @param id            Unique key for identifying the device registration context for the session.
+     * @return              Device registration context cache entry.
+     */
+    private DeviceRegistrationRequestCacheEntry getFromSessionStore(String id) {
+
+        return (DeviceRegistrationRequestCacheEntry) SessionDataStore.getInstance().getSessionData(id,
+                DEVICE_REGISTRATION_REQUEST_CACHE);
+    }
+
+    /**
+     * Clear device registration context from session store.
+     *
+     * @param id            Unique key for identifying the device registration context for the session.
+     */
+    private void clearFromSessionStore(String id) {
+
+        SessionDataStore.getInstance().clearSessionData(id, DEVICE_REGISTRATION_REQUEST_CACHE);
     }
 }

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceRegistrationContextManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceRegistrationContextManagerImplTest.java
@@ -24,10 +24,16 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
 import org.wso2.carbon.identity.notification.push.device.handler.cache.DeviceRegistrationRequestCache;
 import org.wso2.carbon.identity.notification.push.device.handler.cache.DeviceRegistrationRequestCacheEntry;
 import org.wso2.carbon.identity.notification.push.device.handler.cache.DeviceRegistrationRequestCacheKey;
 import org.wso2.carbon.identity.notification.push.device.handler.model.DeviceRegistrationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for DeviceRegistrationContextManagerImpl.
@@ -50,9 +56,15 @@ public class DeviceRegistrationContextManagerImplTest {
         String tenantDomain = "carbon.super";
 
         try (MockedStatic<DeviceRegistrationRequestCache> mockedCache
-                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class)) {
+                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class);
+             MockedStatic<SessionDataStore> mockedSessionDataStore = Mockito.mockStatic(SessionDataStore.class)
+        ) {
             DeviceRegistrationRequestCache cache = Mockito.mock(DeviceRegistrationRequestCache.class);
             mockedCache.when(DeviceRegistrationRequestCache::getInstance).thenReturn(cache);
+
+            SessionDataStore sessionDataStore = Mockito.mock(SessionDataStore.class);
+            mockedSessionDataStore.when(SessionDataStore::getInstance).thenReturn(sessionDataStore);
+            doNothing().when(sessionDataStore).storeSessionData(any(), any(), any());
 
             deviceRegistrationContextManager.storeRegistrationContext(key, context, tenantDomain);
 
@@ -81,11 +93,18 @@ public class DeviceRegistrationContextManagerImplTest {
         String tenantDomain = "carbon.super";
 
         try (MockedStatic<DeviceRegistrationRequestCache> mockedCache
-                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class)) {
+                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class);
+             MockedStatic<SessionDataStore> mockedSessionDataStore = Mockito.mockStatic(SessionDataStore.class)
+        ) {
             DeviceRegistrationRequestCache cache = Mockito.mock(DeviceRegistrationRequestCache.class);
             mockedCache.when(DeviceRegistrationRequestCache::getInstance).thenReturn(cache);
             Mockito.when(cache.getValueFromCache(new DeviceRegistrationRequestCacheKey(key), tenantDomain))
                     .thenReturn(new DeviceRegistrationRequestCacheEntry(context));
+
+            SessionDataStore sessionDataStore = Mockito.mock(SessionDataStore.class);
+            mockedSessionDataStore.when(SessionDataStore::getInstance).thenReturn(sessionDataStore);
+            DeviceRegistrationRequestCacheEntry entry = new DeviceRegistrationRequestCacheEntry(null);
+            when(sessionDataStore.getSessionData(anyString(), anyString())).thenReturn(entry);
 
             DeviceRegistrationContext result = deviceRegistrationContextManager.getContext(key, tenantDomain);
 
@@ -101,11 +120,18 @@ public class DeviceRegistrationContextManagerImplTest {
         String tenantDomain = "carbon.super";
 
         try (MockedStatic<DeviceRegistrationRequestCache> mockedCache
-                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class)) {
+                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class);
+             MockedStatic<SessionDataStore> mockedSessionDataStore = Mockito.mockStatic(SessionDataStore.class)
+        ) {
             DeviceRegistrationRequestCache cache = Mockito.mock(DeviceRegistrationRequestCache.class);
             mockedCache.when(DeviceRegistrationRequestCache::getInstance).thenReturn(cache);
             Mockito.when(cache.getValueFromCache(new DeviceRegistrationRequestCacheKey(key), tenantDomain))
                     .thenReturn(null);
+
+            SessionDataStore sessionDataStore = Mockito.mock(SessionDataStore.class);
+            mockedSessionDataStore.when(SessionDataStore::getInstance).thenReturn(sessionDataStore);
+            DeviceRegistrationRequestCacheEntry entry = new DeviceRegistrationRequestCacheEntry(null);
+            when(sessionDataStore.getSessionData(anyString(), anyString())).thenReturn(entry);
 
             DeviceRegistrationContext result = deviceRegistrationContextManager.getContext(key, tenantDomain);
 
@@ -119,10 +145,17 @@ public class DeviceRegistrationContextManagerImplTest {
         String key = "testKey";
         String tenantDomain = "carbon.super";
 
-        try (MockedStatic<DeviceRegistrationRequestCache> mockedCache
-                     = Mockito.mockStatic(DeviceRegistrationRequestCache.class)) {
+        try (MockedStatic<DeviceRegistrationRequestCache> mockedCache =
+                     Mockito.mockStatic(DeviceRegistrationRequestCache.class);
+            MockedStatic<SessionDataStore> mockedSessionDataStore = Mockito.mockStatic(SessionDataStore.class)
+        ) {
+
             DeviceRegistrationRequestCache cache = Mockito.mock(DeviceRegistrationRequestCache.class);
             mockedCache.when(DeviceRegistrationRequestCache::getInstance).thenReturn(cache);
+
+            SessionDataStore sessionDataStore = Mockito.mock(SessionDataStore.class);
+            mockedSessionDataStore.when(SessionDataStore::getInstance).thenReturn(sessionDataStore);
+            doNothing().when(sessionDataStore).clearSessionData(key, "DEVICE_REGISTRATION_REQUEST_CACHE");
 
             deviceRegistrationContextManager.clearContext(key, tenantDomain);
 


### PR DESCRIPTION
This PR contains implementation to store the PushDeviceRegistrationRequestCache into the temp session DB. This will avoid cache persistence issue in a multi node environment.

Also an error message during the device registration flow has been improved.