### PR TITLE
Implement device token and device name update from mobile feature

### DIFF
--- a/components/org.wso2.carbon.identity.notification.push.common/src/main/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidator.java
+++ b/components/org.wso2.carbon.identity.notification.push.common/src/main/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.notification.push.common/src/main/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidator.java
+++ b/components/org.wso2.carbon.identity.notification.push.common/src/main/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidator.java
@@ -36,6 +36,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * JWT token validator for Push notification scenarios.
@@ -79,6 +80,21 @@ public class PushChallengeValidator {
         } catch (ParseException e) {
             throw new PushTokenValidationException("Error occurred while parsing the JWT token.", e);
         }
+    }
+
+    /**
+     * Validate the JWT token and return the claim values.
+     *
+     * @param jwt       JWT token to be validated
+     * @param publicKey Public key used for signing the JWT
+     * @return Map of claim values
+     * @throws PushTokenValidationException Error when validating the JWT token
+     */
+    public static Map<String, Object> getValidatedClaims(String jwt, String publicKey)
+            throws PushTokenValidationException {
+
+        JWTClaimsSet claimsSet = getValidatedClaimSet(jwt, publicKey);
+        return claimsSet.getClaims();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.notification.push.common/src/test/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidatorTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.common/src/test/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.notification.push.common/src/test/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidatorTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.common/src/test/java/org/wso2/carbon/identity/notification/push/common/PushChallengeValidatorTest.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.identity.notification.push.common.exception.PushTokenVali
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -138,6 +140,89 @@ public class PushChallengeValidatorTest {
             when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
             when(mockSignedJWT.verify(any())).thenReturn(true);
             PushChallengeValidator.getValidatedClaimSet(validJwt, publicKey);
+        }
+    }
+
+    @Test
+    public void testGetValidatedClaimsWithValidToken() throws Exception {
+
+        try (MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)) {
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            Map<String, Object> expectedClaims = new HashMap<>();
+            expectedClaims.put("chg", "e0c3d04c-750b-4301-8f76-e07ebf02e53a");
+            expectedClaims.put("td", "carbon.super");
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+            when(mockClaimsSet.getClaims()).thenReturn(expectedClaims);
+
+            Map<String, Object> claims = PushChallengeValidator.getValidatedClaims(validJwt, publicKey);
+            assertNotNull(claims);
+        }
+    }
+
+    @Test(expectedExceptions = PushTokenValidationException.class)
+    public void testGetValidatedClaimsWithBlankToken() throws Exception {
+
+        PushChallengeValidator.getValidatedClaims("", publicKey);
+    }
+
+    @Test(expectedExceptions = PushTokenValidationException.class)
+    public void testGetValidatedClaimsWithInvalidJwtToken() throws Exception {
+
+        PushChallengeValidator.getValidatedClaims(invalidJwt, publicKey);
+    }
+
+    @Test(expectedExceptions = PushTokenValidationException.class)
+    public void testGetValidatedClaimsWithExpiredToken() throws Exception {
+
+        try (MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)) {
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+            PushChallengeValidator.getValidatedClaims(validJwt, publicKey);
+        }
+    }
+
+    @Test(expectedExceptions = PushTokenValidationException.class)
+    public void testGetValidatedClaimsWithInvalidSignature() throws Exception {
+
+        try (MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)) {
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(null);
+            PushChallengeValidator.getValidatedClaims(validJwt, invalidPublicKey);
+        }
+    }
+
+    @Test
+    public void testGetValidatedClaimsReturnsCorrectClaimValues() throws Exception {
+
+        try (MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)) {
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            Map<String, Object> expectedClaims = new HashMap<>();
+            expectedClaims.put("td", "carbon.super");
+            expectedClaims.put("pid", "f5ae6a0d-390a-4eea-a380-8bcc86e4a148");
+            expectedClaims.put("chg", "e0c3d04c-750b-4301-8f76-e07ebf02e53a");
+            expectedClaims.put("res", "APPROVED");
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+            when(mockClaimsSet.getClaims()).thenReturn(expectedClaims);
+
+            Map<String, Object> claims = PushChallengeValidator.getValidatedClaims(validJwt, publicKey);
+            assertNotNull(claims);
+            Assert.assertEquals(claims.get("td"), "carbon.super");
+            Assert.assertEquals(claims.get("pid"), "f5ae6a0d-390a-4eea-a380-8bcc86e4a148");
+            Assert.assertEquals(claims.get("chg"), "e0c3d04c-750b-4301-8f76-e07ebf02e53a");
+            Assert.assertEquals(claims.get("res"), "APPROVED");
+            Assert.assertEquals(claims.size(), 4);
         }
     }
 

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/DeviceHandlerService.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/DeviceHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -91,6 +91,15 @@ public interface DeviceHandlerService {
      * @throws PushDeviceHandlerException Push Device Handler Exception.
      */
     void editDevice(String deviceId, String path, String value) throws PushDeviceHandlerException;
+
+    /**
+     * Edit the device from mobile.
+     *
+     * @param deviceId Device ID.
+     * @param token Token.
+     * @throws PushDeviceHandlerException Push Device Handler Exception.
+     */
+    void editDeviceMobile(String deviceId, String token) throws PushDeviceHandlerException;
 
     /**
      * Get registration discovery data.

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/DeviceHandlerService.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/DeviceHandlerService.java
@@ -99,7 +99,7 @@ public interface DeviceHandlerService {
      * @param token Token.
      * @throws PushDeviceHandlerException Push Device Handler Exception.
      */
-    void editDeviceMobile(String deviceId, String token) throws PushDeviceHandlerException;
+    default void editDeviceMobile(String deviceId, String token) throws PushDeviceHandlerException{}
 
     /**
      * Get registration discovery data.

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
@@ -58,7 +58,7 @@ public class PushDeviceHandlerConstants {
         public static final String GET_PUBLIC_KEY_BY_ID = "SELECT PUBLIC_KEY FROM IDN_PUSH_DEVICE_STORE " +
                 "WHERE ID = :ID;";
         public static final String UNREGISTER_DEVICE = "DELETE FROM IDN_PUSH_DEVICE_STORE WHERE ID = :ID;";
-        public static final String EDIT_DEVICE = "UPDATE IDN_PUSH_DEVICE_STORE SET DEVICE_NAME = :DEVICE_NAME; " +
+        public static final String EDIT_DEVICE = "UPDATE IDN_PUSH_DEVICE_STORE SET DEVICE_NAME = :DEVICE_NAME;, " +
                 "DEVICE_TOKEN = :DEVICE_TOKEN; WHERE ID = :ID;";
     }
 

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
@@ -30,8 +30,8 @@ public class PushDeviceHandlerConstants {
     public static final String DEVICE_REGISTRATION_CONTEXT_VALIDITY_PERIOD =
             "PushAuthenticator.DeviceRegistrationContext.ValidityPeriod";
     public static final int DEFAULT_DEVICE_REGISTRATION_CONTEXT_VALIDITY_PERIOD = 180;
-    public static final String DEVICE_EDIT_REQUEST_DEVICE_NAME = "name";
-    public static final String DEVICE_EDIT_REQUEST_DEVICE_TOKEN = "deviceToken";
+    public static final String DEVICE_NAME = "name";
+    public static final String DEVICE_TOKEN = "deviceToken";
 
     /**
      * Private constructor to prevent initialization of the class.
@@ -141,7 +141,7 @@ public class PushDeviceHandlerConstants {
         ),
         ERROR_CODE_DEVICE_EDIT_FAILED(
                 "PDH-150014",
-                "Error occurred while editing the device for the device ID: %s."
+                "Error occurred while updating the device for the device ID: %s."
         );
 
         private final String code;

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/constant/PushDeviceHandlerConstants.java
@@ -30,6 +30,8 @@ public class PushDeviceHandlerConstants {
     public static final String DEVICE_REGISTRATION_CONTEXT_VALIDITY_PERIOD =
             "PushAuthenticator.DeviceRegistrationContext.ValidityPeriod";
     public static final int DEFAULT_DEVICE_REGISTRATION_CONTEXT_VALIDITY_PERIOD = 180;
+    public static final String DEVICE_EDIT_REQUEST_DEVICE_NAME = "name";
+    public static final String DEVICE_EDIT_REQUEST_DEVICE_TOKEN = "deviceToken";
 
     /**
      * Private constructor to prevent initialization of the class.
@@ -136,6 +138,10 @@ public class PushDeviceHandlerConstants {
         ERROR_CODE_FAILED_TO_RESOLVE_PUSH_PROVIDER(
                 "PDH-15013",
                 "Failed to resolve the correct push provider for the request."
+        ),
+        ERROR_CODE_DEVICE_EDIT_FAILED(
+                "PDH-150014",
+                "Error occurred while editing the device for the device ID: %s."
         );
 
         private final String code;

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.notification.push.device.handler.impl;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -71,7 +72,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEFAULT_PUSH_PROVIDER;
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_EDIT_REQUEST_DEVICE_NAME;
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_EDIT_REQUEST_DEVICE_TOKEN;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_ALREADY_REGISTERED;
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_EDIT_FAILED;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_NOT_FOUND;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_NOT_FOUND_FOR_USER_ID;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_REGISTRATION_FAILED;
@@ -245,6 +249,57 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
 
         Device device = getDevice(deviceId);
         handleEditDevice(device, path, value);
+    }
+
+    @Override
+    public void editDeviceMobile(String deviceId, String token) throws PushDeviceHandlerException {
+
+        Optional<Device> deviceOptional = deviceDAO.getDevice(deviceId);
+        if (!deviceOptional.isPresent()) {
+            throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_NOT_FOUND.getCode(),
+                    String.format(ERROR_CODE_DEVICE_NOT_FOUND.getMessage(), deviceId));
+        }
+        Device device = deviceOptional.get();
+
+        JWTClaimsSet claimsSet;
+        try {
+            claimsSet = PushChallengeValidator.getValidatedClaimSet(token, device.getPublicKey());
+        } catch (PushTokenValidationException e) {
+            throw new PushDeviceHandlerClientException(ERROR_CODE_TOKEN_CLAIM_VERIFICATION_FAILED.getCode(),
+                    String.format(ERROR_CODE_TOKEN_CLAIM_VERIFICATION_FAILED.getMessage(), deviceId), e);
+        }
+
+        String deviceToken = null;
+        String deviceName = null;
+
+        try {
+            if (claimsSet.getClaims().containsKey(DEVICE_EDIT_REQUEST_DEVICE_TOKEN)) {
+                deviceToken = PushChallengeValidator
+                        .getClaimFromClaimSet(claimsSet, DEVICE_EDIT_REQUEST_DEVICE_TOKEN, deviceId);
+            }
+
+            if (claimsSet.getClaims().containsKey(DEVICE_EDIT_REQUEST_DEVICE_NAME)) {
+                deviceName = PushChallengeValidator
+                        .getClaimFromClaimSet(claimsSet, DEVICE_EDIT_REQUEST_DEVICE_NAME, deviceId);
+            }
+        } catch (PushTokenValidationException e) {
+            throw new PushDeviceHandlerClientException(e.getErrorCode(), e.getMessage(), e);
+        }
+
+        if (deviceToken == null && deviceName == null) {
+            throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_EDIT_FAILED.getCode(),
+                    String.format(ERROR_CODE_DEVICE_EDIT_FAILED.getMessage(), deviceId));
+        }
+
+        if (deviceToken != null) {
+            device.setDeviceToken(deviceToken);
+        }
+        if (deviceName != null) {
+            device.setDeviceName(deviceName);
+        }
+
+        handleUpdateDeviceForProvider(device);
+        deviceDAO.editDevice(device.getDeviceId(), device);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
@@ -71,8 +71,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEFAULT_PUSH_PROVIDER;
-import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_EDIT_REQUEST_DEVICE_NAME;
-import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_EDIT_REQUEST_DEVICE_TOKEN;
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_NAME;
+import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.DEVICE_TOKEN;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_ALREADY_REGISTERED;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_EDIT_FAILED;
 import static org.wso2.carbon.identity.notification.push.device.handler.constant.PushDeviceHandlerConstants.ErrorMessages.ERROR_CODE_DEVICE_NOT_FOUND;
@@ -268,20 +268,17 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
                     String.format(ERROR_CODE_TOKEN_CLAIM_VERIFICATION_FAILED.getMessage(), deviceId), e);
         }
 
+        validateDeviceEditClaims(claims, deviceId);
+
         String deviceToken = null;
         String deviceName = null;
 
-        try {
-            if (claims.containsKey(DEVICE_EDIT_REQUEST_DEVICE_TOKEN)) {
-                deviceToken = (String) claims.get(DEVICE_EDIT_REQUEST_DEVICE_TOKEN);
-            }
+        if (claims.containsKey(DEVICE_TOKEN)) {
+            deviceToken = (String) claims.get(DEVICE_TOKEN);
+        }
 
-            if (claims.containsKey(DEVICE_EDIT_REQUEST_DEVICE_NAME)) {
-                deviceName = (String) claims.get(DEVICE_EDIT_REQUEST_DEVICE_NAME);
-            }
-        } catch (ClassCastException e) {
-            throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_EDIT_FAILED.getCode(),
-                    String.format(ERROR_CODE_DEVICE_EDIT_FAILED.getMessage(), deviceId), e);
+        if (claims.containsKey(DEVICE_NAME)) {
+            deviceName = (String) claims.get(DEVICE_NAME);
         }
 
         if (deviceToken == null && deviceName == null) {
@@ -724,5 +721,26 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
         pushSenderData.setProperties(pushSenderDTO.getProperties());
         pushSenderData.setProviderId(pushSenderDTO.getProviderId());
         return pushSenderData;
+    }
+
+    /**
+     * Validate the claims in the edit device token.
+     *
+     * @param claims   Claims to validate.
+     * @param deviceId Device ID for error messages.
+     * @throws PushDeviceHandlerClientException If the claims are invalid.
+     */
+    private static void validateDeviceEditClaims(Map<String, Object> claims, String deviceId)
+            throws PushDeviceHandlerClientException {
+
+        if (claims.containsKey(DEVICE_TOKEN) && !(claims.get(DEVICE_TOKEN) instanceof String)) {
+            throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_EDIT_FAILED.getCode(),
+                    String.format(ERROR_CODE_DEVICE_EDIT_FAILED.getMessage(), deviceId));
+        }
+
+        if (claims.containsKey(DEVICE_NAME) && !(claims.get(DEVICE_NAME) instanceof String)) {
+            throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_EDIT_FAILED.getCode(),
+                    String.format(ERROR_CODE_DEVICE_EDIT_FAILED.getMessage(), deviceId));
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.notification.push.device.handler.impl;
 
-import com.nimbusds.jwt.JWTClaimsSet;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -261,9 +260,9 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
         }
         Device device = deviceOptional.get();
 
-        JWTClaimsSet claimsSet;
+        Map<String, Object> claims;
         try {
-            claimsSet = PushChallengeValidator.getValidatedClaimSet(token, device.getPublicKey());
+            claims = PushChallengeValidator.getValidatedClaims(token, device.getPublicKey());
         } catch (PushTokenValidationException e) {
             throw new PushDeviceHandlerClientException(ERROR_CODE_TOKEN_CLAIM_VERIFICATION_FAILED.getCode(),
                     String.format(ERROR_CODE_TOKEN_CLAIM_VERIFICATION_FAILED.getMessage(), deviceId), e);
@@ -273,24 +272,22 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
         String deviceName = null;
 
         try {
-            if (claimsSet.getClaims().containsKey(DEVICE_EDIT_REQUEST_DEVICE_TOKEN)) {
-                deviceToken = PushChallengeValidator
-                        .getClaimFromClaimSet(claimsSet, DEVICE_EDIT_REQUEST_DEVICE_TOKEN, deviceId);
+            if (claims.containsKey(DEVICE_EDIT_REQUEST_DEVICE_TOKEN)) {
+                deviceToken = (String) claims.get(DEVICE_EDIT_REQUEST_DEVICE_TOKEN);
             }
 
-            if (claimsSet.getClaims().containsKey(DEVICE_EDIT_REQUEST_DEVICE_NAME)) {
-                deviceName = PushChallengeValidator
-                        .getClaimFromClaimSet(claimsSet, DEVICE_EDIT_REQUEST_DEVICE_NAME, deviceId);
+            if (claims.containsKey(DEVICE_EDIT_REQUEST_DEVICE_NAME)) {
+                deviceName = (String) claims.get(DEVICE_EDIT_REQUEST_DEVICE_NAME);
             }
-        } catch (PushTokenValidationException e) {
-            throw new PushDeviceHandlerClientException(e.getErrorCode(), e.getMessage(), e);
+        } catch (ClassCastException e) {
+            throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_EDIT_FAILED.getCode(),
+                    String.format(ERROR_CODE_DEVICE_EDIT_FAILED.getMessage(), deviceId), e);
         }
 
         if (deviceToken == null && deviceName == null) {
             throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_EDIT_FAILED.getCode(),
                     String.format(ERROR_CODE_DEVICE_EDIT_FAILED.getMessage(), deviceId));
         }
-
         if (deviceToken != null) {
             device.setDeviceToken(deviceToken);
         }

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImpl.java
@@ -138,6 +138,11 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
             device = handleDeviceRegistration(registrationRequest, context);
             if (context.isRegistered()) {
                 deviceRegistrationContextManager.clearContext(registrationRequest.getDeviceId(), tenantDomain);
+                AUDIT_LOGGER.printAuditLog(
+                        DeviceHandlerAuditLogger.Operation.REGISTER_DEVICE,
+                        deviceId,
+                        device.getUserId()
+                );
             } else {
                 throw new PushDeviceHandlerClientException(ERROR_CODE_DEVICE_REGISTRATION_FAILED.getCode(),
                         String.format(ERROR_CODE_DEVICE_REGISTRATION_FAILED.getMessage(), deviceId));
@@ -248,6 +253,11 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
 
         Device device = getDevice(deviceId);
         handleEditDevice(device, path, value);
+        AUDIT_LOGGER.printAuditLog(
+                DeviceHandlerAuditLogger.Operation.UPDATE_DEVICE,
+                deviceId,
+                device.getUserId()
+        );
     }
 
     @Override
@@ -294,6 +304,11 @@ public class DeviceHandlerServiceImpl implements DeviceHandlerService {
 
         handleUpdateDeviceForProvider(device);
         deviceDAO.editDevice(device.getDeviceId(), device);
+        AUDIT_LOGGER.printAuditLog(
+                DeviceHandlerAuditLogger.Operation.UPDATE_DEVICE,
+                deviceId,
+                device.getUserId()
+        );
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/utils/DeviceHandlerAuditLogger.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/main/java/org/wso2/carbon/identity/notification/push/device/handler/utils/DeviceHandlerAuditLogger.java
@@ -45,7 +45,7 @@ public class DeviceHandlerAuditLogger {
      */
     public void printAuditLog(Operation operation, String deviceId, String userId) {
 
-        JSONObject data = createAuditLogEntry(userId);
+        JSONObject data = createAuditLogEntry(operation, userId);
         buildAuditLog(operation, deviceId, data);
     }
 
@@ -72,11 +72,21 @@ public class DeviceHandlerAuditLogger {
      *
      * @return Audit log data.
      */
-    private JSONObject createAuditLogEntry(String userId) {
+    private JSONObject createAuditLogEntry(Operation operation, String userId) {
 
         JSONObject data = new JSONObject();
         data.put(LogConstants.END_USER_ID, userId != null ? userId : JSONObject.NULL);
-        data.put(LogConstants.UNREGISTERED_AT, System.currentTimeMillis());
+        switch (operation) {
+            case REGISTER_DEVICE:
+                data.put(LogConstants.REGISTERED_AT, System.currentTimeMillis());
+                break;
+            case UPDATE_DEVICE:
+                data.put(LogConstants.UPDATED_AT, System.currentTimeMillis());
+                break;
+            case UNREGISTER_DEVICE:
+                data.put(LogConstants.UNREGISTERED_AT, System.currentTimeMillis());
+                break;
+        }
 
         return data;
     }
@@ -128,6 +138,8 @@ public class DeviceHandlerAuditLogger {
      */
     public enum Operation {
 
+        REGISTER_DEVICE("Register-Push-Auth-Device"),
+        UPDATE_DEVICE("Update-Push-Auth-Device"),
         UNREGISTER_DEVICE("Unregister-Push-Auth-Device");
 
         private final String logAction;
@@ -150,6 +162,8 @@ public class DeviceHandlerAuditLogger {
 
         public static final String TARGET_TYPE_FIELD = "Push-Auth-Device";
         public static final String END_USER_ID = "UserId";
+        public static final String REGISTERED_AT = "RegisteredAt";
+        public static final String UPDATED_AT = "UpdatedAt";
         public static final String UNREGISTERED_AT = "UnregisteredAt";
     }
 }

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/dao/DeviceDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/dao/DeviceDAOImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/dao/DeviceDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/dao/DeviceDAOImplTest.java
@@ -42,7 +42,7 @@ public class DeviceDAOImplTest {
             "DEVICE_MODEL, DEVICE_TOKEN, DEVICE_HANDLE, PROVIDER, PUBLIC_KEY, TENANT_ID) VALUES " +
             "( ? ,  ? ,  ? ,  ? ,  ? ,  ? ,  ? ,  ? ,  ? )";
     public static final String UNREGISTER_DEVICE_TEST = "DELETE FROM IDN_PUSH_DEVICE_STORE WHERE ID =  ? ";
-    public static final String EDIT_DEVICE_TEST = "UPDATE IDN_PUSH_DEVICE_STORE SET DEVICE_NAME =  ?  " +
+    public static final String EDIT_DEVICE_TEST = "UPDATE IDN_PUSH_DEVICE_STORE SET DEVICE_NAME =  ? , " +
             "DEVICE_TOKEN =  ?  WHERE ID =  ? ";
     private DeviceDAOImpl deviceDAO;
 

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImplTest.java
@@ -1011,6 +1011,412 @@ public class DeviceHandlerServiceImplTest {
     }
 
     @Test
+    public void testEditDeviceMobileWithBothFields()
+            throws PushDeviceHandlerException, NotificationSenderManagementException, PushProviderException,
+            JOSEException, ParseException {
+
+        try (
+                MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                        Mockito.mockStatic(IdentityTenantUtil.class);
+                MockedStatic<PushDeviceHandlerDataHolder> mockedPushDeviceHandlerDataHolder =
+                        Mockito.mockStatic(PushDeviceHandlerDataHolder.class);
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(any())).thenReturn(-1234);
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("deviceToken", "newDeviceToken");
+            claims.put("name", "newDeviceName");
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+            when(mockClaimsSet.getStringClaim("deviceToken")).thenReturn("newDeviceToken");
+            when(mockClaimsSet.getStringClaim("name")).thenReturn("newDeviceName");
+
+            PushDeviceHandlerDataHolder pushDeviceHandlerDataHolder = mock(PushDeviceHandlerDataHolder.class);
+            mockedPushDeviceHandlerDataHolder.when(PushDeviceHandlerDataHolder::getInstance)
+                    .thenReturn(pushDeviceHandlerDataHolder);
+
+            NotificationSenderManagementService notificationSenderManagementService =
+                    mock(NotificationSenderManagementService.class);
+            when(pushDeviceHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO pushSenderDTO = new PushSenderDTO();
+            pushSenderDTO.setName("FCM_PushPublisher");
+            pushSenderDTO.setProvider("FCM");
+            pushSenderDTO.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(pushSenderDTO);
+            when(notificationSenderManagementService.getPushSenders(anyBoolean()))
+                    .thenReturn(pushSenders);
+
+            FCMPushProvider fcmPushProvider = mock(FCMPushProvider.class);
+            when(pushDeviceHandlerDataHolder.getPushProvider(eq("FCM"))).thenReturn(fcmPushProvider);
+            when(fcmPushProvider.getName()).thenReturn("FCM");
+            doNothing().when(fcmPushProvider).updateDevice(any(), any());
+
+            doNothing().when(deviceDAO).editDevice(anyString(), any());
+            Mockito.clearInvocations(deviceDAO);
+
+            deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+
+            verify(fcmPushProvider, times(1)).updateDevice(any(), any());
+            verify(deviceDAO, times(1)).editDevice(anyString(), any());
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileWithTokenOnly()
+            throws PushDeviceHandlerException, NotificationSenderManagementException, PushProviderException,
+            JOSEException, ParseException {
+
+        try (
+                MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                        Mockito.mockStatic(IdentityTenantUtil.class);
+                MockedStatic<PushDeviceHandlerDataHolder> mockedPushDeviceHandlerDataHolder =
+                        Mockito.mockStatic(PushDeviceHandlerDataHolder.class);
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(any())).thenReturn(-1234);
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("deviceToken", "newDeviceToken");
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+            when(mockClaimsSet.getStringClaim("deviceToken")).thenReturn("newDeviceToken");
+
+            PushDeviceHandlerDataHolder pushDeviceHandlerDataHolder = mock(PushDeviceHandlerDataHolder.class);
+            mockedPushDeviceHandlerDataHolder.when(PushDeviceHandlerDataHolder::getInstance)
+                    .thenReturn(pushDeviceHandlerDataHolder);
+
+            NotificationSenderManagementService notificationSenderManagementService =
+                    mock(NotificationSenderManagementService.class);
+            when(pushDeviceHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO pushSenderDTO = new PushSenderDTO();
+            pushSenderDTO.setName("FCM_PushPublisher");
+            pushSenderDTO.setProvider("FCM");
+            pushSenderDTO.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(pushSenderDTO);
+            when(notificationSenderManagementService.getPushSenders(anyBoolean()))
+                    .thenReturn(pushSenders);
+
+            FCMPushProvider fcmPushProvider = mock(FCMPushProvider.class);
+            when(pushDeviceHandlerDataHolder.getPushProvider(eq("FCM"))).thenReturn(fcmPushProvider);
+            when(fcmPushProvider.getName()).thenReturn("FCM");
+            doNothing().when(fcmPushProvider).updateDevice(any(), any());
+
+            doNothing().when(deviceDAO).editDevice(anyString(), any());
+            Mockito.clearInvocations(deviceDAO);
+
+            deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+
+            verify(fcmPushProvider, times(1)).updateDevice(any(), any());
+            verify(deviceDAO, times(1)).editDevice(anyString(), any());
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileWithNameOnly()
+            throws PushDeviceHandlerException, NotificationSenderManagementException, PushProviderException,
+            JOSEException, ParseException {
+
+        try (
+                MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                        Mockito.mockStatic(IdentityTenantUtil.class);
+                MockedStatic<PushDeviceHandlerDataHolder> mockedPushDeviceHandlerDataHolder =
+                        Mockito.mockStatic(PushDeviceHandlerDataHolder.class);
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(any())).thenReturn(-1234);
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("name", "newDeviceName");
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+            when(mockClaimsSet.getStringClaim("name")).thenReturn("newDeviceName");
+
+            PushDeviceHandlerDataHolder pushDeviceHandlerDataHolder = mock(PushDeviceHandlerDataHolder.class);
+            mockedPushDeviceHandlerDataHolder.when(PushDeviceHandlerDataHolder::getInstance)
+                    .thenReturn(pushDeviceHandlerDataHolder);
+
+            NotificationSenderManagementService notificationSenderManagementService =
+                    mock(NotificationSenderManagementService.class);
+            when(pushDeviceHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO pushSenderDTO = new PushSenderDTO();
+            pushSenderDTO.setName("FCM_PushPublisher");
+            pushSenderDTO.setProvider("FCM");
+            pushSenderDTO.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(pushSenderDTO);
+            when(notificationSenderManagementService.getPushSenders(anyBoolean()))
+                    .thenReturn(pushSenders);
+
+            FCMPushProvider fcmPushProvider = mock(FCMPushProvider.class);
+            when(pushDeviceHandlerDataHolder.getPushProvider(eq("FCM"))).thenReturn(fcmPushProvider);
+            when(fcmPushProvider.getName()).thenReturn("FCM");
+            doNothing().when(fcmPushProvider).updateDevice(any(), any());
+
+            doNothing().when(deviceDAO).editDevice(anyString(), any());
+            Mockito.clearInvocations(deviceDAO);
+
+            deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+
+            verify(fcmPushProvider, times(1)).updateDevice(any(), any());
+            verify(deviceDAO, times(1)).editDevice(anyString(), any());
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileDeviceNotFound() throws PushDeviceHandlerException {
+
+        Optional<Device> device = Optional.empty();
+        when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+        Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+            deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+        });
+    }
+
+    @Test
+    public void testEditDeviceMobileTokenValidationFailed()
+            throws PushDeviceHandlerException, JOSEException, ParseException {
+
+        try (
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(false);
+
+            Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileNoEditableFields()
+            throws PushDeviceHandlerException, JOSEException, ParseException {
+
+        try (
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            Map<String, Object> claims = new HashMap<>();
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+
+            Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileProviderClientException()
+            throws PushDeviceHandlerException, NotificationSenderManagementException, PushProviderException,
+            JOSEException, ParseException {
+
+        try (
+                MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                        Mockito.mockStatic(IdentityTenantUtil.class);
+                MockedStatic<PushDeviceHandlerDataHolder> mockedPushDeviceHandlerDataHolder =
+                        Mockito.mockStatic(PushDeviceHandlerDataHolder.class);
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(any())).thenReturn(-1234);
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("deviceToken", "newDeviceToken");
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+            when(mockClaimsSet.getStringClaim("deviceToken")).thenReturn("newDeviceToken");
+
+            PushDeviceHandlerDataHolder pushDeviceHandlerDataHolder = mock(PushDeviceHandlerDataHolder.class);
+            mockedPushDeviceHandlerDataHolder.when(PushDeviceHandlerDataHolder::getInstance)
+                    .thenReturn(pushDeviceHandlerDataHolder);
+
+            NotificationSenderManagementService notificationSenderManagementService =
+                    mock(NotificationSenderManagementService.class);
+            when(pushDeviceHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO pushSenderDTO = new PushSenderDTO();
+            pushSenderDTO.setName("FCM_PushPublisher");
+            pushSenderDTO.setProvider("FCM");
+            pushSenderDTO.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(pushSenderDTO);
+            when(notificationSenderManagementService.getPushSenders(anyBoolean()))
+                    .thenReturn(pushSenders);
+
+            FCMPushProvider fcmPushProvider = mock(FCMPushProvider.class);
+            when(pushDeviceHandlerDataHolder.getPushProvider(eq("FCM"))).thenReturn(fcmPushProvider);
+            when(fcmPushProvider.getName()).thenReturn("FCM");
+            PushProviderClientException ppce = new PushProviderClientException(
+                    "ERR_DEVICE_UPDATE", "Failed to update device at provider");
+            doThrow(ppce).when(fcmPushProvider).updateDevice(any(), any());
+
+            Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileProviderServerException()
+            throws PushDeviceHandlerException, NotificationSenderManagementException, PushProviderException,
+            JOSEException, ParseException {
+
+        try (
+                MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                        Mockito.mockStatic(IdentityTenantUtil.class);
+                MockedStatic<PushDeviceHandlerDataHolder> mockedPushDeviceHandlerDataHolder =
+                        Mockito.mockStatic(PushDeviceHandlerDataHolder.class);
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(any())).thenReturn(-1234);
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("deviceToken", "newDeviceToken");
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+            when(mockClaimsSet.getStringClaim("deviceToken")).thenReturn("newDeviceToken");
+
+            PushDeviceHandlerDataHolder pushDeviceHandlerDataHolder = mock(PushDeviceHandlerDataHolder.class);
+            mockedPushDeviceHandlerDataHolder.when(PushDeviceHandlerDataHolder::getInstance)
+                    .thenReturn(pushDeviceHandlerDataHolder);
+
+            NotificationSenderManagementService notificationSenderManagementService =
+                    mock(NotificationSenderManagementService.class);
+            when(pushDeviceHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO pushSenderDTO = new PushSenderDTO();
+            pushSenderDTO.setName("FCM_PushPublisher");
+            pushSenderDTO.setProvider("FCM");
+            pushSenderDTO.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(pushSenderDTO);
+            when(notificationSenderManagementService.getPushSenders(anyBoolean()))
+                    .thenReturn(pushSenders);
+
+            PushProviderServerException ppse = new PushProviderServerException(
+                    "ERR_PROVIDER_SERVER", "Provider service temporarily unavailable");
+            org.wso2.carbon.identity.notification.push.provider.PushProvider pushProvider =
+                    mock(org.wso2.carbon.identity.notification.push.provider.PushProvider.class);
+            when(pushDeviceHandlerDataHolder.getPushProvider(eq("FCM"))).thenReturn(pushProvider);
+            when(pushProvider.getName()).thenReturn("FCM");
+            doThrow(ppse).when(pushProvider).updateDevice(any(), any());
+
+            Assert.assertThrows(PushDeviceHandlerServerException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
     public void testGetRegistrationDiscoveryData() throws PushDeviceHandlerException {
 
         try (

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/impl/DeviceHandlerServiceImplTest.java
@@ -1225,6 +1225,109 @@ public class DeviceHandlerServiceImplTest {
     }
 
     @Test
+    public void testEditDeviceMobileWithInvalidDeviceTokenClaimType()
+            throws PushDeviceHandlerException, JOSEException, ParseException {
+
+        try (
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            // Set deviceToken claim as a non-String type (Integer) to trigger validation failure.
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("deviceToken", 12345);
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+
+            Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileWithInvalidDeviceNameClaimType()
+            throws PushDeviceHandlerException, JOSEException, ParseException {
+
+        try (
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            // Set name claim as a non-String type (Boolean) to trigger validation failure.
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("name", true);
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+
+            Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
+    public void testEditDeviceMobileWithBothInvalidClaimTypes()
+            throws PushDeviceHandlerException, JOSEException, ParseException {
+
+        try (
+                MockedStatic<SignedJWT> mockedStatic = Mockito.mockStatic(SignedJWT.class)
+        ) {
+
+            Device deviceObj = new Device();
+            deviceObj.setDeviceId("1234567890");
+            deviceObj.setProvider("FCM");
+            deviceObj.setDeviceToken(deviceToken);
+            deviceObj.setPublicKey(publicKey);
+            Optional<Device> device = Optional.of(deviceObj);
+            when(deviceDAO.getDevice(anyString())).thenReturn(device);
+
+            mockedStatic.when(() -> SignedJWT.parse(validJwt)).thenReturn(mockSignedJWT);
+
+            when(mockSignedJWT.getJWTClaimsSet()).thenReturn(mockClaimsSet);
+            when(mockClaimsSet.getExpirationTime()).thenReturn(new Date(System.currentTimeMillis() + 3000000));
+            when(mockClaimsSet.getNotBeforeTime()).thenReturn(new Date(System.currentTimeMillis() - 3000000));
+            when(mockSignedJWT.verify(any())).thenReturn(true);
+
+            // Set both claims as non-String types. The deviceToken check runs first.
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("deviceToken", 12345);
+            claims.put("name", 67890);
+            when(mockClaimsSet.getClaims()).thenReturn(claims);
+
+            Assert.assertThrows(PushDeviceHandlerClientException.class, () -> {
+                deviceHandlerService.editDeviceMobile("1234567890", validJwt);
+            });
+        }
+    }
+
+    @Test
     public void testEditDeviceMobileTokenValidationFailed()
             throws PushDeviceHandlerException, JOSEException, ParseException {
 

--- a/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/utils/DeviceHandlerAuditLoggerTest.java
+++ b/components/org.wso2.carbon.identity.notification.push.device.handler/src/test/java/org/wso2/carbon/identity/notification/push/device/handler/utils/DeviceHandlerAuditLoggerTest.java
@@ -130,15 +130,57 @@ public class DeviceHandlerAuditLoggerTest {
     public void testCreateAuditLogEntryWithValidData() throws Exception {
 
         Method createAuditLogEntryMethod = DeviceHandlerAuditLogger.class
-                .getDeclaredMethod("createAuditLogEntry", String.class);
+                .getDeclaredMethod("createAuditLogEntry",
+                        DeviceHandlerAuditLogger.Operation.class, String.class);
         createAuditLogEntryMethod.setAccessible(true);
-        JSONObject result = (JSONObject) createAuditLogEntryMethod.invoke(auditLogger, "testUserId");
+        JSONObject result = (JSONObject) createAuditLogEntryMethod.invoke(
+                auditLogger, DeviceHandlerAuditLogger.Operation.UNREGISTER_DEVICE, "testUserId");
 
         Assert.assertNotNull(result);
         Assert.assertTrue(result.has("UserId"));
         Assert.assertEquals(result.getString("UserId"), "testUserId");
         Assert.assertTrue(result.has("UnregisteredAt"));
         Assert.assertTrue(result.getLong("UnregisteredAt") > 0);
+    }
+
+    /**
+     * Test the private method 'createAuditLogEntry' with register device operation.
+     */
+    @Test
+    public void testCreateAuditLogEntryWithRegisterDevice() throws Exception {
+
+        Method createAuditLogEntryMethod = DeviceHandlerAuditLogger.class
+                .getDeclaredMethod("createAuditLogEntry",
+                        DeviceHandlerAuditLogger.Operation.class, String.class);
+        createAuditLogEntryMethod.setAccessible(true);
+        JSONObject result = (JSONObject) createAuditLogEntryMethod.invoke(
+                auditLogger, DeviceHandlerAuditLogger.Operation.REGISTER_DEVICE, "testUserId");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.has("UserId"));
+        Assert.assertEquals(result.getString("UserId"), "testUserId");
+        Assert.assertTrue(result.has("RegisteredAt"));
+        Assert.assertTrue(result.getLong("RegisteredAt") > 0);
+    }
+
+    /**
+     * Test the private method 'createAuditLogEntry' with update device operation.
+     */
+    @Test
+    public void testCreateAuditLogEntryWithUpdateDevice() throws Exception {
+
+        Method createAuditLogEntryMethod = DeviceHandlerAuditLogger.class
+                .getDeclaredMethod("createAuditLogEntry",
+                        DeviceHandlerAuditLogger.Operation.class, String.class);
+        createAuditLogEntryMethod.setAccessible(true);
+        JSONObject result = (JSONObject) createAuditLogEntryMethod.invoke(
+                auditLogger, DeviceHandlerAuditLogger.Operation.UPDATE_DEVICE, "testUserId");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.has("UserId"));
+        Assert.assertEquals(result.getString("UserId"), "testUserId");
+        Assert.assertTrue(result.has("UpdatedAt"));
+        Assert.assertTrue(result.getLong("UpdatedAt") > 0);
     }
 
     /**


### PR DESCRIPTION
## Purpose
 Add support for editing/updating device properties (device name and device token) from mobile devices. Currently, once a device is registered for push notifications, there is no way to update its name or FCM token from the mobile side.

## Related Issue
 - https://github.com/wso2/product-is/issues/26207

## Related PRs
 - https://github.com/wso2/identity-api-user/pull/289
 - https://github.com/wso2/carbon-identity-framework/pull/8086

## Goals
 - Allow mobile devices to update their device name and/or device token after registration.
 - Validate the edit request using JWT token verification to ensure the request originates from the legitimate device.
 - Expose the edit functionality through the `DeviceHandlerService` interface.

## Approach
 - Added a new `editDeviceMobile(String deviceId, String token)` method to `DeviceHandlerService` interface and its implementation in `DeviceHandlerServiceImpl`.
 - The method retrieves the device by ID, validates the incoming JWT token against the device's stored public key using `PushChallengeValidator.getValidatedClaims()`, extracts the updated device token and/or device name from the validated claims, and persists the changes.
 - Added a new `getValidatedClaims()` method to `PushChallengeValidator` that returns JWT claims as a `Map<String, Object` for easier consumption.
 - Added the `EDIT_DEVICE` SQL query constant and related claim constants (`DEVICE_EDIT_REQUEST_DEVICE_TOKEN`, `DEVICE_EDIT_REQUEST_DEVICE_NAME`) to `PushDeviceHandlerConstants`.
 - The device provider is also updated via `handleUpdateDeviceForProvider()` to keep the push provider (e.g., FCM) in sync.

## User stories
 As a mobile app user, I want to be able to update my device's push notification token or device name so that push notifications continue to work correctly after token rotation or when I rename my device.

## Release note
 Added support for editing device name and device token from mobile devices in the push notification device handler. Edit requests are validated using JWT token verification.

## Documentation
 N/A - This is an internal API change for the push notification component. API documentation should be updated when the consuming REST API layer exposes this functionality.

## Training
 N/A

## Certification
 N/A - Internal component change with no direct impact on certification content.

## Marketing
 N/A

## Automation tests
 - Unit tests
    - Added 6 new unit tests for `PushChallengeValidator.getValidatedClaims()` covering valid token, blank token, invalid JWT, expired token, invalid signature, and claim value verification scenarios.
    - Added unit tests for `DeviceHandlerServiceImpl.editDeviceMobile()` covering successful device update, device not found, token validation failure, missing edit fields, and class cast exception scenarios.
 - Integration tests
    N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
 N/A

## Migrations (if applicable)
 No migrations required. The `EDIT_DEVICE` SQL operation uses existing database columns.

## Learning
 Leveraged the existing `PushChallengeValidator` JWT validation pattern and extended it to support returning claims as a Map for more flexible claim extraction in the device edit flow.