### PR TITLE
Bump httpcore5 to 5.4.3.wso2v1 and httpclient5 to 5.6.3.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,9 +386,9 @@
         <nimbusds.osgi.version.range>[10.3.0,11.0.0)</nimbusds.osgi.version.range>
         <json-smart.version>2.4.10</json-smart.version>
         <json-smart.osgi.version.range>[2.3.0,3.0.0)</json-smart.osgi.version.range>
-        <httpclient5.version>5.4.1.wso2v1</httpclient5.version>
+        <httpclient5.version>5.6.3.wso2v1</httpclient5.version>
         <httpclient5.osgi.version.range>[5.0.0,6.0.0)</httpclient5.osgi.version.range>
-        <httpcore5.version>5.3.1.wso2v1</httpcore5.version>
+        <httpcore5.version>5.4.3.wso2v1</httpcore5.version>
         <httpcore5.osgi.version.range>[5.0.0,6.0.0)</httpcore5.osgi.version.range>
         <commons.logging.version>1.2</commons.logging.version>
         <org.apache.commons.logging.range>[1.2.0,2.0.0)</org.apache.commons.logging.range>


### PR DESCRIPTION
## Purpose

| CVE | Severity | Affected artifact | Installed | Fixed in |
|---|---|---|---|---|
| [CVE-2026-54399](https://avd.aquasec.com/nvd/cve-2026-54399) | HIGH | `httpcore5` — DoS via excessive HTTP headers | 5.3.1 | 5.4.3 |
| [CVE-2026-54428](https://avd.aquasec.com/nvd/cve-2026-54428) | HIGH | `httpcore5-h2` — DoS via oversized HTTP/2 HPACK headers | 5.3.1 | 5.4.3 |
| [CVE-2026-64607](https://avd.aquasec.com/nvd/cve-2026-64607) | MEDIUM | `httpclient5` — connection leak on Content-Encoding decode error → pool exhaustion | 5.4.1 | 5.6.3 |

## Why this repo

**This feature is the one that actually ships the vulnerable bundles into the Identity Server distribution.**

I built the IS 7.4.0-SNAPSHOT pack and traced `repository/components/plugins/httpclient5_5.4.1.wso2v1.jar` and `httpcore5_5.3.1.wso2v1.jar` back through the p2 repository. Exactly one feature contributes them:

```
org.wso2.carbon.identity.notification.push_1.2.3.jar
  <plugin id="httpcore5"   unpack="false" version="5.3.1.wso2v1"/>
  <plugin id="httpclient5" unpack="false" version="5.4.1.wso2v1"/>
```

carbon-kernel, carbon-identity-framework and identity-governance also pin these orbit versions and are being bumped in parallel, but none of them place the bundles in the distribution.

## Why the scanner did not report it

These orbit bundles **inline** the upstream classes and carry only a WSO2 GAV:

```
META-INF/maven/org.wso2.orbit.org.apache.httpcomponents/httpclient5/pom.properties
META-INF/maven/org.wso2.orbit.org.apache.httpcomponents/httpcore5/pom.properties
```

so GAV matching against the upstream coordinates never fires. The same three CVEs *were* reported against `yubico-webauthn_2.5.1.wso2v1.jar`, which embeds the upstream jars whole and so kept their original `pom.properties`. The versions here are older than the ones that were flagged: 5.4.1 < 5.5 and 5.3.1 < 5.3.4.

## Version pairing

`httpclient5-parent-5.6.3` sets `httpcore.version=5.4.3`, so 5.6.3 + 5.4.3 is the combination Apache builds and tests against. The existing OSGi ranges in this pom (`[5.0.0,6.0.0)`) already accommodate both.

## Verification

Built locally with JDK 21 (`mvn clean install -Dmaven.test.skip=true`) against a locally installed `httpclient5 5.6.3.wso2v1` — BUILD SUCCESS. The server feature now packages:

```
plugins/httpcore5-5.4.3.wso2v1.jar
plugins/httpclient5-5.6.3.wso2v1.jar
```

## Related

- wso2/orbit#1405 — adds the `httpclient5 5.6.3.wso2v1` bundle
- wso2/carbon-kernel#4619, wso2/carbon-identity-framework#8253, wso2-extensions/identity-governance#1155 — same bump in the other repos that pin these versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
